### PR TITLE
Fixed memory leaks

### DIFF
--- a/src-cpp/randomjs/Literal.h
+++ b/src-cpp/randomjs/Literal.h
@@ -27,9 +27,9 @@ public:
 	static Literal Zero;
 	Literal(const char* value) : value(value) {}
 	Literal(int32_t val) {
-		StringBuilder* sb = new StringBuilder();
+		StringBuilder* sb = new (LinearAllocator::getInstance().allocate(sizeof(StringBuilder))) StringBuilder();
 		*sb << val;
-		String* str = new String(sb->str());
+		String* str = new (LinearAllocator::getInstance().allocate(sizeof(String))) String(sb->str());
 		value = str->data();
 	}
 	virtual uint32_t getType() {

--- a/src-cpp/randomjs/ProgramFactory.cpp
+++ b/src-cpp/randomjs/ProgramFactory.cpp
@@ -320,7 +320,7 @@ NumericLiteral* ProgramFactory::genNumericLiteral() {
 }
 
 NumericLiteral* ProgramFactory::genNumericLiteral(EnumType type) {
-	String* str = new String();
+	String* str = new (LinearAllocator::getInstance().allocate(sizeof(String))) String();
 	str->reserve(37);
 	bool negative = false;
 	if (type != NumericLiteralType::Boolean && rand.flipCoin()) {

--- a/src-cpp/randomjs/RandomUtility.cpp
+++ b/src-cpp/randomjs/RandomUtility.cpp
@@ -70,7 +70,7 @@ const char* RandomUtility::genStringLiteral(RandomGenerator& rand, int length) {
 
 const char* RandomUtility::genStringLiteral(RandomGenerator& rand, int length, const std::string& charset) {
 	char quote = rand.flipCoin() ? '\'' : '"';
-	String* str = new String();
+	String* str = new (LinearAllocator::getInstance().allocate(sizeof(String))) String();
 	str->reserve(2 * length);
 	str->push_back(quote);
 	while (length-- > 0) {

--- a/src-cpp/randomjs/Variable.cpp
+++ b/src-cpp/randomjs/Variable.cpp
@@ -24,7 +24,7 @@ along with RandomJS.  If not, see<http://www.gnu.org/licenses/>.
 Variable Variable::This = Variable(nullptr, "this", true, false);
 
 const char* Variable::getVariableName(int index) {
-	String* str = new String();
+	String* str = new (LinearAllocator::getInstance().allocate(sizeof(String))) String();
 	while (index >= 0) {
 		int mod = index % 26;
 		str->push_back((char)('a' + mod));

--- a/src-cpp/randomjs/VariableSelector.cpp
+++ b/src-cpp/randomjs/VariableSelector.cpp
@@ -26,9 +26,9 @@ VariableSelector::VariableSelector() {}
 
 void VariableSelector::init() {
 	currentScope = nullptr;
-	readableVars = new List<Variable*>();
+	readableVars = new (LinearAllocator::getInstance().allocate(sizeof(List<Variable*>))) List<Variable*>();
 	readableVars->reserve(50);
-	writableVars = new List<Variable*>();
+	writableVars = new (LinearAllocator::getInstance().allocate(sizeof(List<Variable*>))) List<Variable*>();
 	writableVars->reserve(50);
 }
 


### PR DESCRIPTION
When you call "new String()", it uses default memory allocator to allocate memory for String object before creating it, so memory leaks here and in other similar places. Need to use placement new and call LinearAllocator explicitly.